### PR TITLE
cleanup collocation and add tests

### DIFF
--- a/lumos/optimal_control/scaled_mesh_ocp.py
+++ b/lumos/optimal_control/scaled_mesh_ocp.py
@@ -475,7 +475,7 @@ class ScaledMeshOCP(CompositeProblem):
             if isinstance(self.transcription, LGR):
                 interval_mesh = (
                     interval * interval_length
-                    + (self.transcription.interp_points + 1) / 2 * interval_length
+                    + self.transcription.interp_points * interval_length
                 )
             else:
                 interval_mesh = np.array([interval, interval + 1]) * interval_length

--- a/tests/test_optimal_control/test_transcription.py
+++ b/tests/test_optimal_control/test_transcription.py
@@ -1,5 +1,7 @@
-from re import L
 import unittest
+
+import numpy as np
+from scipy.interpolate import lagrange
 
 from lumos.optimal_control.transcription import (
     get_transcription_options,
@@ -50,7 +52,60 @@ class TestMakeTranscription(unittest.TestCase):
 
 
 class TestTranscription(unittest.TestCase):
-    @unittest.skip("To be implemented")
-    def test_continuity_transcription(self):
-        """Test if the transcription of a continuous time system is accurate."""
-        raise NotImplementedError
+    def test_LGR_continuity(self):
+        """Test LGR differentiation and residual computations are correct"""
+        num_stages = 5
+        lgr = make_transcription("LGR", {"num_stages": num_stages})
+        A_diff, B_diff = lgr.get_continuity_matrices()
+        x = np.random.randn(num_stages)
+        s = lgr.interp_points
+        poly = lagrange(s, x)
+
+        # Test derivatives are correct.
+        x_dot_expected = poly.deriv()(s[1:])
+        x_dot_actual = A_diff @ x
+        np.testing.assert_array_almost_equal(x_dot_actual, x_dot_expected)
+
+        # Test with the correct x and x_dot, continuity equations are satisfied
+        # need to add an x_dot to the first point to make size match. The first point of
+        # x_dot is not collocated, so we can add any random number..
+        res = A_diff @ x - B_diff @ np.insert(x_dot_expected, 0, 0)
+        np.testing.assert_array_almost_equal(res, np.zeros_like(res))
+
+    def test_LGRIntegral_continuity(self):
+        """Test LGRIntegral integral and residual computations are correct"""
+        num_stages = 5
+        lgr_int = make_transcription("LGRIntegral", {"num_stages": num_stages})
+        A, B = lgr_int.get_continuity_matrices()
+        x = np.random.randn(num_stages)
+        s = lgr_int.interp_points
+        poly = lagrange(s, x)
+        x_dot_actual = poly.deriv()(s)
+
+        # Test integrals are correct.
+        x_actual = x[0] + B @ x_dot_actual
+        x_expected = x[1:]
+        np.testing.assert_array_almost_equal(x_actual, x_expected)
+
+        # Test with the correct x and x_dot, continuity equations are satisfied
+        res = A @ x - B @ x_dot_actual
+        np.testing.assert_array_almost_equal(res, np.zeros_like(res))
+
+    def test_LGR_invertible(self):
+        """LGR scheme can be inverted to reconstruct states from derivatives.
+        
+        See equation 72-73 on Garg, Rao, et al, 2017, https://hal.archives-ouvertes.fr/hal-01615132
+        An overview of three pseudospectral methods for the numerical solution of
+        optimal control problems
+        """
+
+        num_stages = 5
+        lgr = make_transcription("LGR", {"num_stages": num_stages})
+        A, B = lgr.get_continuity_matrices()
+
+        x = np.sin(5 * np.linspace(0, 1, num_stages))
+        x_dot = A @ x
+
+        x_reconstructed = np.linalg.solve(A[:, 1:], x_dot) + x[0]
+
+        np.testing.assert_array_almost_equal(x_reconstructed, x[1:])


### PR DESCRIPTION
- make it cleaner such that transcription users directly uses a
collocation interval of [0, 1], instead of [-1, 1].
- add tests to ensure collocation continuity and some other properties
such as LGR invertibility are satisfied