### PR TITLE
use named io instead of pure vectors

### DIFF
--- a/examples/brachistochrone.py
+++ b/examples/brachistochrone.py
@@ -64,18 +64,18 @@ class TimeModel(StateSpaceModel):
         mesh: float = 0.0,  # time invariant model
     ) -> StateSpaceModelReturn:
         params = self._params
-        theta = self.get_input(inputs, "theta")
-        v = self.get_state(states, "v")
+        theta = inputs["theta"]
+        v = states["v"]
         v_dot = -params["gravity"] * lnp.sin(theta)
 
         dx_dt = lnp.cos(theta) * v
         dy_dt = lnp.sin(theta) * v
 
         # Assemble result
-        states_dot = self.make_vector(
+        states_dot = self.make_dict(
             group="states_dot", v_dot=v_dot, x_dot=dx_dt, y_dot=dy_dt,
         )
-        outputs = self.make_vector(group="outputs", theta=theta)
+        outputs = self.make_dict(group="outputs", theta=theta)
         return self.make_state_space_model_return(
             states_dot=states_dot, outputs=outputs
         )
@@ -244,9 +244,9 @@ class DistanceModel(StateSpaceModel):
         mesh: float = 0.0,  # time invariant model
     ) -> StateSpaceModelReturn:
         params = self._params
-        theta = self.get_input(inputs, "theta")
+        theta = inputs["theta"]
         dv_dt = -params["gravity"] * lnp.sin(theta)
-        v = self.get_state(states, "v")
+        v = states["v"]
         vx = v * lnp.cos(theta)
 
         # dvx_dt = dv_dt * lnp.cos(theta)
@@ -255,7 +255,7 @@ class DistanceModel(StateSpaceModel):
         time_dot = 1 / (vx + 1e-9)
         y_dot = lnp.tan(theta)
         # Assemble result
-        states_dot = self.make_vector(
+        states_dot = self.make_dict(
             group="states_dot", time_dot=time_dot, v_dot=v_dot, y_dot=y_dot,
         )
 

--- a/examples/brachistochrone.py
+++ b/examples/brachistochrone.py
@@ -72,9 +72,7 @@ class TimeModel(StateSpaceModel):
         dy_dt = lnp.sin(theta) * v
 
         # Assemble result
-        states_dot = self.make_dict(
-            group="states_dot", v_dot=v_dot, x_dot=dx_dt, y_dot=dy_dt,
-        )
+        states_dot = self.make_dict(group="states_dot", v=v_dot, x=dx_dt, y=dy_dt,)
         outputs = self.make_dict(group="outputs", theta=theta)
         return self.make_state_space_model_return(
             states_dot=states_dot, outputs=outputs
@@ -256,7 +254,7 @@ class DistanceModel(StateSpaceModel):
         y_dot = lnp.tan(theta)
         # Assemble result
         states_dot = self.make_dict(
-            group="states_dot", time_dot=time_dot, v_dot=v_dot, y_dot=y_dot,
+            group="states_dot", time=time_dot, v=v_dot, y=y_dot,
         )
 
         return self.make_state_space_model_return(states_dot=states_dot)

--- a/examples/drone_example.py
+++ b/examples/drone_example.py
@@ -14,7 +14,7 @@ def main():
         sim_config=DroneSimulation.get_sim_config(
             num_intervals=99,
             hessian_approximation=h_approx,
-            backend="jax",
+            backend="casadi",
             transcription="LGR",
             is_condensed=False,
         )

--- a/examples/laptime_simulation_example.py
+++ b/examples/laptime_simulation_example.py
@@ -1,6 +1,7 @@
 import logging
 import os
 
+from lumos.models.composition import ModelMaker
 from lumos.models.simple_vehicle_on_track import SimpleVehicleOnTrack
 from lumos.models.tires.utils import create_params_from_tir_file
 from lumos.simulations.laptime_simulation import LaptimeSimulation
@@ -37,7 +38,9 @@ def main():
     model_config = SimpleVehicleOnTrack.get_recursive_default_model_config()
 
     # EXAMPLE: change tire model
-    # model_config.replace_subtree("vehicle.tire", ModelMaker.make_config("PerantoniTire"))
+    # model_config.replace_subtree(
+    #     "vehicle.tire", ModelMaker.make_config("PerantoniTire")
+    # )
 
     # EXMAPLE: change an aero model
     # model_config.replace_subtree("vehicle.aero", ModelMaker.make_config("MLPAero"))

--- a/lumos/models/aero/aero.py
+++ b/lumos/models/aero/aero.py
@@ -39,8 +39,8 @@ class GPAero(AeroModel):
         # we might want to make the I/O names dynamic that are only defined after the
         # object is instantiated (for example, passing all submodel outputs as a part of
         # parent model outputs)
-        num_inputs = len(cls.get_cls_group_names("inputs"))
-        num_outputs = len(cls.get_cls_group_names("outputs"))
+        num_inputs = len(cls.get_direct_group_names("inputs"))
+        num_outputs = len(cls.get_direct_group_names("outputs"))
         return {
             "gp_points": np.random.randn(cls.num_points, num_inputs),
             "alpha": np.random.randn(num_outputs, cls.num_points),
@@ -75,8 +75,8 @@ class MLPAero(AeroModel):
 
     @classmethod
     def get_default_params(cls):
-        num_inputs = len(cls.get_cls_group_names("inputs"))
-        num_outputs = len(cls.get_cls_group_names("outputs"))
+        num_inputs = len(cls.get_direct_group_names("inputs"))
+        num_outputs = len(cls.get_direct_group_names("outputs"))
 
         layers_dim = [cls.layer_dim] * cls.num_layers
         ins = [num_inputs] + layers_dim[:-1]

--- a/lumos/models/aero/aero.py
+++ b/lumos/models/aero/aero.py
@@ -24,7 +24,7 @@ class ConstAero(AeroModel):
         return {"Cx": 0.6, "Cy": 0.0, "Cz": 1.9}
 
     def forward(self, inputs):
-        return ModelReturn(outputs=self.make_vector("outputs", **self._params))
+        return ModelReturn(outputs=self._params)
 
 
 class GPAero(AeroModel):

--- a/lumos/models/base.py
+++ b/lumos/models/base.py
@@ -270,7 +270,7 @@ class Model(CompositeModel):
         self._check_keys(group, kwargs)
         return lnp.array(list(kwargs[name] for name in self.get_group_names(group)))
 
-    def make_dict(self, group: str, **kwargs) -> lnp.ndarray:
+    def make_dict(self, group: str, **kwargs) -> Dict[str, Any]:
         """Create a dictionary from kwargs. All values must be provided.
         
         This is actually just a thing wrapper on the standard dictionary construction,
@@ -279,6 +279,9 @@ class Model(CompositeModel):
         """
         self._check_keys(group, kwargs)
         return kwargs
+
+    def make_const_dict(self, group, value: float) -> Dict[str, Any]:
+        return {n: value for n in self.get_group_names(group)}
 
     def plot(self, *args, **kwargs):
         raise NotImplementedError

--- a/lumos/models/base.py
+++ b/lumos/models/base.py
@@ -64,10 +64,9 @@ def state_space_io(
                 "StateSpaceModel. Use model_io for other models"
             )
 
-        states_dot = tuple([n + "_dot" for n in states])
         cls.names = StateSpaceIO(
             states=states,
-            states_dot=states_dot,
+            states_dot=states,
             inputs=inputs,
             outputs=outputs,
             con_outputs=con_outputs,

--- a/lumos/models/drone_model.py
+++ b/lumos/models/drone_model.py
@@ -27,25 +27,20 @@ class DroneModel(StateSpaceModel):
         mesh: float = 0.0,  # time invariant model
     ) -> StateSpaceModelReturn:
         params = self._params
-        theta = self.get_state(states, "theta")
-        x_dot_dot = self.get_input(inputs, "f") * lnp.sin(theta)
-        z_dot_dot = self.get_input(inputs, "f") * lnp.cos(theta) - params["gravity"]
+        theta = states["theta"]
+        x_dot_dot = inputs["f"] * lnp.sin(theta)
+        z_dot_dot = inputs["f"] * lnp.cos(theta) - params["gravity"]
 
         # Assemble result
-        states_dot = self.make_vector(
-            group="states",
-            x=self.get_state(states, "x_dot"),
-            x_dot=x_dot_dot,
-            z=self.get_state(states, "z_dot"),
-            z_dot=z_dot_dot,
-            theta=self.get_input(inputs, "omega"),
+        states_dot = dict(
+            x_dot=states["x_dot"],
+            x_dot_dot=x_dot_dot,
+            z_dot=states["z_dot"],
+            z_dot_dot=z_dot_dot,
+            theta_dot=inputs["omega"],
         )
 
-        outputs = self.make_vector(
-            group="outputs",
-            sin_theta=lnp.sin(theta),
-            f_omega=self.get_input(inputs, "omega") * self.get_input(inputs, "f"),
-        )
+        outputs = dict(sin_theta=lnp.sin(theta), f_omega=inputs["omega"] * inputs["f"],)
 
         return self.make_state_space_model_return(
             states_dot=states_dot, outputs=outputs,

--- a/lumos/models/drone_model.py
+++ b/lumos/models/drone_model.py
@@ -1,4 +1,5 @@
 import logging
+from re import X
 
 from typing import Any, Dict
 
@@ -32,15 +33,18 @@ class DroneModel(StateSpaceModel):
         z_dot_dot = inputs["f"] * lnp.cos(theta) - params["gravity"]
 
         # Assemble result
-        states_dot = dict(
-            x_dot=states["x_dot"],
-            x_dot_dot=x_dot_dot,
-            z_dot=states["z_dot"],
-            z_dot_dot=z_dot_dot,
-            theta_dot=inputs["omega"],
+        states_dot = self.make_dict(
+            "states_dot",
+            x=states["x_dot"],
+            x_dot=x_dot_dot,
+            z=states["z_dot"],
+            z_dot=z_dot_dot,
+            theta=inputs["omega"],
         )
 
-        outputs = dict(sin_theta=lnp.sin(theta), f_omega=inputs["omega"] * inputs["f"],)
+        outputs = self.make_dict(
+            "outputs", sin_theta=lnp.sin(theta), f_omega=inputs["omega"] * inputs["f"],
+        )
 
         return self.make_state_space_model_return(
             states_dot=states_dot, outputs=outputs,

--- a/lumos/models/kinematics.py
+++ b/lumos/models/kinematics.py
@@ -36,15 +36,15 @@ class TrackPosition2D(StateSpaceModel):
             y to the left of the vehicle as seen by the driver
         """
 
-        n = self.get_state(states, "n")
-        eta = self.get_state(states, "eta")
-        vx = self.get_input(inputs, "vx")
-        vy = self.get_input(inputs, "vy")
-        yaw_rate = self.get_input(inputs, "yaw_rate")
+        n = states["n"]
+        eta = states["eta"]
+        vx = inputs["vx"]
+        vy = inputs["vy"]
+        yaw_rate = inputs["yaw_rate"]
 
-        curvature = self.get_input(inputs, "track_curvature")
-        track_heading = self.get_input(inputs, "track_heading")
-        yaw_angle = self.get_state(states, "eta") + track_heading
+        curvature = inputs["track_curvature"]
+        track_heading = inputs["track_heading"]
+        yaw_angle = states["eta"] + track_heading
 
         ds_dt = (vx * lnp.cos(eta) - vy * lnp.sin(eta)) / (1 - n * curvature)
         dn_dt = vx * lnp.sin(eta) + vy * lnp.cos(eta)
@@ -52,12 +52,10 @@ class TrackPosition2D(StateSpaceModel):
 
         # Pure kinematics related calculation. This is where vehicle models will be
         # executed in the future
-        states_dot = self.make_vector(
-            group="states", time=1 / ds_dt, n=dn_dt / ds_dt, eta=deta_dt / ds_dt,
+        states_dot = dict(
+            time_dot=1 / ds_dt, n_dot=dn_dt / ds_dt, eta_dot=deta_dt / ds_dt,
         )
-        outputs = self.make_vector(
-            group="outputs", yaw_angle=yaw_angle, curvature=curvature
-        )
+        outputs = dict(yaw_angle=yaw_angle, curvature=curvature)
         return self.make_state_space_model_return(
             states_dot=states_dot, outputs=outputs
         )

--- a/lumos/models/kinematics.py
+++ b/lumos/models/kinematics.py
@@ -52,10 +52,10 @@ class TrackPosition2D(StateSpaceModel):
 
         # Pure kinematics related calculation. This is where vehicle models will be
         # executed in the future
-        states_dot = dict(
-            time_dot=1 / ds_dt, n_dot=dn_dt / ds_dt, eta_dot=deta_dt / ds_dt,
+        states_dot = self.make_dict(
+            "states_dot", time=1 / ds_dt, n=dn_dt / ds_dt, eta=deta_dt / ds_dt,
         )
-        outputs = dict(yaw_angle=yaw_angle, curvature=curvature)
+        outputs = self.make_dict("outputs", yaw_angle=yaw_angle, curvature=curvature)
         return self.make_state_space_model_return(
             states_dot=states_dot, outputs=outputs
         )

--- a/lumos/models/simple_vehicle_on_track.py
+++ b/lumos/models/simple_vehicle_on_track.py
@@ -8,16 +8,22 @@ from lumos.models.vehicles.simple_vehicle import SimpleVehicle
 
 # Combine the signals to create the names. TODO: can we make it more automatic?
 @state_space_io(
-    states=TrackPosition2D.get_group_names("states")
-    + SimpleVehicle.get_group_names("states"),
-    inputs=SimpleVehicle.get_group_names("inputs")
+    states=TrackPosition2D.get_cls_group_names("states")
+    + SimpleVehicle.get_cls_group_names("states"),
+    inputs=SimpleVehicle.get_cls_group_names("inputs")
     + ("track_curvature", "track_heading"),
-    outputs=TrackPosition2D.get_group_names("outputs")
-    + SimpleVehicle.get_group_names("outputs"),
-    con_outputs=TrackPosition2D.get_group_names("con_outputs")
-    + SimpleVehicle.get_group_names("con_outputs"),
-    residuals=TrackPosition2D.get_group_names("residuals")
-    + SimpleVehicle.get_group_names("residuals"),
+    con_outputs=(
+        "vehicle.slip_ratio_fl",
+        "vehicle.slip_ratio_fr",
+        "vehicle.slip_ratio_rl",
+        "vehicle.slip_ratio_rr",
+        "vehicle.slip_angle_fl",
+        "vehicle.slip_angle_fr",
+        "vehicle.slip_angle_rl",
+        "vehicle.slip_angle_rr",
+    ),
+    residuals=TrackPosition2D.get_cls_group_names("residuals")
+    + SimpleVehicle.get_cls_group_names("residuals"),
 )
 class SimpleVehicleOnTrack(StateSpaceModel):
     _submodel_names = ("vehicle", "kinematics")
@@ -98,7 +104,9 @@ class SimpleVehicleOnTrack(StateSpaceModel):
             **{k: v * dt_ds for k, v in vehicle_return.states_dot.items()},
         }
 
-        outputs = {**kinematics_return.outputs, **vehicle_return.outputs}
+        outputs = self.combine_submodel_outputs(
+            vehicle=vehicle_return.outputs, kinematics=kinematics_return.outputs
+        )
 
         residuals = vehicle_return.residuals
 

--- a/lumos/models/simple_vehicle_on_track.py
+++ b/lumos/models/simple_vehicle_on_track.py
@@ -98,7 +98,7 @@ class SimpleVehicleOnTrack(StateSpaceModel):
         # ordering when the are created
 
         # Convert to distance domain derivatives
-        dt_ds = kinematics_return.states_dot["time_dot"]
+        dt_ds = kinematics_return.states_dot["time"]
         states_dot = {
             **kinematics_return.states_dot,
             **{k: v * dt_ds for k, v in vehicle_return.states_dot.items()},

--- a/lumos/models/test_utils.py
+++ b/lumos/models/test_utils.py
@@ -177,7 +177,7 @@ class BaseStateSpaceModelTest(BaseModelTest):
         for _ in range(num_steps):
             model_return = self.model.forward(states, inputs)
             for k in states:
-                states[k] += model_return.states_dot[k + "_dot"] * time_step
+                states[k] += model_return.states_dot[k] * time_step
 
         return states, model_return.outputs
 

--- a/lumos/models/test_utils.py
+++ b/lumos/models/test_utils.py
@@ -174,8 +174,8 @@ class BaseStateSpaceModelTest(BaseModelTest):
 
         # Ensure we don't modify the initial states
         states = dict(init_states)
-        for _ in range(num_steps):
-            model_return = self.model.forward(states, inputs)
+        for step in range(num_steps):
+            model_return = self.model.forward(states, inputs, step * time_step)
             for k in states:
                 states[k] += model_return.states_dot[k] * time_step
 

--- a/lumos/models/tires/pacejka.py
+++ b/lumos/models/tires/pacejka.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 import numpy as np
 
-NUM_OUTPUTS = 100
+NUM_OUTPUTS = 1000
 OUTPUT_NAMES = tuple([f"dummy_{i}" for i in range(NUM_OUTPUTS)])
 OUTPUT_VALUES = np.ones(NUM_OUTPUTS)
 

--- a/lumos/models/tires/pacejka.py
+++ b/lumos/models/tires/pacejka.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 import numpy as np
 
-NUM_OUTPUTS = 30
+NUM_OUTPUTS = 100
 OUTPUT_NAMES = tuple([f"dummy_{i}" for i in range(NUM_OUTPUTS)])
 OUTPUT_VALUES = np.ones(NUM_OUTPUTS)
 

--- a/lumos/models/tires/pacejka.py
+++ b/lumos/models/tires/pacejka.py
@@ -240,18 +240,17 @@ class MF52(BaseTire):
         """
 
         # Unpack inputs
-        gamma = self.get_input(inputs, "gamma")
-        vx = self.get_input(inputs, "vx")
-        Fz = self.get_input(inputs, "Fz")
-        kappa = self.get_input(inputs, "kappa")
-        alpha = self.get_input(inputs, "alpha")
+        gamma = inputs["gamma"]
+        vx = inputs["vx"]
+        Fz = inputs["Fz"]
+        kappa = inputs["kappa"]
+        alpha = inputs["alpha"]
 
         (Fx, Fy, Mx, My, Mz, Kxk, Gxa, Kya, Gyk) = self._do_force_and_moments(
             kappa=kappa, alpha=alpha, gamma=gamma, vx=vx, Fz=Fz,
         )
 
-        outputs = self.make_vector(
-            group="outputs",
+        outputs = dict(
             Fx=Fx,
             Fy=Fy,
             Mx=Mx,

--- a/lumos/models/tires/pacejka.py
+++ b/lumos/models/tires/pacejka.py
@@ -7,12 +7,6 @@ from lumos.models.tires.base import BaseTire
 
 logger = logging.getLogger(__name__)
 
-import numpy as np
-
-NUM_OUTPUTS = 1000
-OUTPUT_NAMES = tuple([f"dummy_{i}" for i in range(NUM_OUTPUTS)])
-OUTPUT_VALUES = np.ones(NUM_OUTPUTS)
-
 
 @model_io(
     inputs=(
@@ -22,8 +16,7 @@ OUTPUT_VALUES = np.ones(NUM_OUTPUTS)
         "vx",  # x-velocity in tire coordinate
         "gamma",  # inclination angle
     ),
-    outputs=("Fx", "Fy", "Mx", "My", "Mz", "Kxk", "Gxa", "Kya", "Gyk", "GSum")
-    + OUTPUT_NAMES,
+    outputs=("Fx", "Fy", "Mx", "My", "Mz", "Kxk", "Gxa", "Kya", "Gyk", "GSum"),
 )
 class MF52(BaseTire):
     def __init__(
@@ -269,8 +262,6 @@ class MF52(BaseTire):
             Gyk=Gyk,
             GSum=lnp.sqrt(Gyk ** 2 + Gxa ** 2),
         )
-
-        outputs.update(dict(zip(OUTPUT_NAMES, OUTPUT_VALUES)))
 
         return ModelReturn(outputs=outputs)
 

--- a/lumos/models/tires/pacejka.py
+++ b/lumos/models/tires/pacejka.py
@@ -7,6 +7,12 @@ from lumos.models.tires.base import BaseTire
 
 logger = logging.getLogger(__name__)
 
+import numpy as np
+
+NUM_OUTPUTS = 10
+OUTPUT_NAMES = tuple([f"dummy_{i}" for i in range(NUM_OUTPUTS)])
+OUTPUT_VALUES = np.ones(NUM_OUTPUTS)
+
 
 @model_io(
     inputs=(
@@ -16,7 +22,8 @@ logger = logging.getLogger(__name__)
         "vx",  # x-velocity in tire coordinate
         "gamma",  # inclination angle
     ),
-    outputs=("Fx", "Fy", "Mx", "My", "Mz", "Kxk", "Gxa", "Kya", "Gyk", "GSum"),
+    outputs=("Fx", "Fy", "Mx", "My", "Mz", "Kxk", "Gxa", "Kya", "Gyk", "GSum")
+    + OUTPUT_NAMES,
 )
 class MF52(BaseTire):
     def __init__(
@@ -262,6 +269,8 @@ class MF52(BaseTire):
             Gyk=Gyk,
             GSum=lnp.sqrt(Gyk ** 2 + Gxa ** 2),
         )
+
+        outputs.update(dict(zip(OUTPUT_NAMES, OUTPUT_VALUES)))
 
         return ModelReturn(outputs=outputs)
 

--- a/lumos/models/tires/pacejka.py
+++ b/lumos/models/tires/pacejka.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 import numpy as np
 
-NUM_OUTPUTS = 10
+NUM_OUTPUTS = 30
 OUTPUT_NAMES = tuple([f"dummy_{i}" for i in range(NUM_OUTPUTS)])
 OUTPUT_VALUES = np.ones(NUM_OUTPUTS)
 

--- a/lumos/models/tires/perantoni.py
+++ b/lumos/models/tires/perantoni.py
@@ -42,9 +42,9 @@ class PerantoniTire(BaseTire):
         params = self._params
 
         # unpack inputs
-        kappa = self.get_input(inputs, "kappa")
-        alpha = self.get_input(inputs, "alpha")
-        Fz = self.get_input(inputs, "Fz")
+        kappa = inputs["kappa"]
+        alpha = inputs["alpha"]
+        Fz = inputs["Fz"]
 
         # unpack parameters
         Fz1 = params["Fz1"]
@@ -86,9 +86,7 @@ class PerantoniTire(BaseTire):
         Fy = -muy * Fz * alpha_n / rho
 
         # Fill moments with 0.0
-        outputs = self.make_vector(
-            group="outputs", Fx=Fx, Fy=Fy, Mx=0.0, My=0.0, Mz=0.0
-        )
+        outputs = dict(Fx=Fx, Fy=Fy, Mx=0.0, My=0.0, Mz=0.0)
         return ModelReturn(outputs=outputs)
 
     @classmethod

--- a/lumos/models/vehicles/simple_vehicle.py
+++ b/lumos/models/vehicles/simple_vehicle.py
@@ -87,16 +87,6 @@ def _rotate_z(theta: float) -> lnp.ndarray:
         "slip_angle_rl",
         "slip_angle_rr",
     ),
-    con_outputs=(
-        "slip_ratio_fl",
-        "slip_ratio_fr",
-        "slip_ratio_rl",
-        "slip_ratio_rr",
-        "slip_angle_fl",
-        "slip_angle_fr",
-        "slip_angle_rl",
-        "slip_angle_rr",
-    ),
     residuals=("ax", "ay",),
 )
 class SimpleVehicle(StateSpaceModel):
@@ -389,7 +379,7 @@ class SimpleVehicle(StateSpaceModel):
         outputs.update(submodel_outputs)
 
         residuals = dict(ax=ax - ax_in, ay=ay - ay_in)
-        return self.make_state_space_model_return(
+        return StateSpaceModelReturn(
             states_dot=states_dot, outputs=outputs, residuals=residuals,
         )
 

--- a/lumos/models/vehicles/simple_vehicle.py
+++ b/lumos/models/vehicles/simple_vehicle.py
@@ -338,14 +338,15 @@ class SimpleVehicle(StateSpaceModel):
         vx_dot = ax + yaw_rate * vy
         vy_dot = ay - yaw_rate * vx
 
-        states_dot = dict(
-            vx_dot=vx_dot,
-            vy_dot=vy_dot,
-            yaw_rate_dot=yaw_accel,
-            wheel_speed_fl_dot=wheel_speed_dot["fl"],
-            wheel_speed_fr_dot=wheel_speed_dot["fr"],
-            wheel_speed_rl_dot=wheel_speed_dot["rl"],
-            wheel_speed_rr_dot=wheel_speed_dot["rr"],
+        states_dot = self.make_dict(
+            "states_dot",
+            vx=vx_dot,
+            vy=vy_dot,
+            yaw_rate=yaw_accel,
+            wheel_speed_fl=wheel_speed_dot["fl"],
+            wheel_speed_fr=wheel_speed_dot["fr"],
+            wheel_speed_rl=wheel_speed_dot["rl"],
+            wheel_speed_rr=wheel_speed_dot["rr"],
         )
 
         submodel_outputs = self.combine_submodel_outputs(
@@ -356,7 +357,8 @@ class SimpleVehicle(StateSpaceModel):
             tire_rr=tire_outputs["rr"],
         )
 
-        outputs = dict(
+        outputs = self.make_dict(
+            "outputs",
             ax=ax,
             ay=ay,
             drive_torque_rl=drive_torque_rl,
@@ -374,9 +376,8 @@ class SimpleVehicle(StateSpaceModel):
             Fy_tire_rr=tire_force_in_body_coordinate["rr"][Vector3dEnum.Y],
             Fz_tire_rr=tire_force_in_body_coordinate["rr"][Vector3dEnum.Z],
             **slips,
+            **submodel_outputs,
         )
-
-        outputs.update(submodel_outputs)
 
         residuals = dict(ax=ax - ax_in, ay=ay - ay_in)
         return StateSpaceModelReturn(

--- a/lumos/models/vehicles/simple_vehicle.py
+++ b/lumos/models/vehicles/simple_vehicle.py
@@ -5,7 +5,6 @@ from operator import add
 from typing import Any, Dict
 
 import numpy as np
-from jax import vmap
 
 import lumos.numpy as lnp
 from lumos.models.base import StateSpaceModel, StateSpaceModelReturn, state_space_io
@@ -132,17 +131,17 @@ class SimpleVehicle(StateSpaceModel):
         """
         params = self._params
 
-        throttle = self.get_input(inputs, "throttle")
-        brake = self.get_input(inputs, "brake")
-        steer = self.get_input(inputs, "steer")
-        ax_in = self.get_input(inputs, "ax")
-        ay_in = self.get_input(inputs, "ay")
+        throttle = inputs["throttle"]
+        brake = inputs["brake"]
+        steer = inputs["steer"]
+        ax_in = inputs["ax"]
+        ay_in = inputs["ay"]
 
-        vx = self.get_state(states, "vx")
-        vy = self.get_state(states, "vy")
-        yaw_rate = self.get_state(states, "yaw_rate")
+        vx = states["vx"]
+        vy = states["vy"]
+        yaw_rate = states["yaw_rate"]
 
-        wheel_speed = {c: self.get_state(states, f"wheel_speed_{c}") for c in _corners}
+        wheel_speed = {c: states[f"wheel_speed_{c}"] for c in _corners}
 
         max_power = params["max_power"]
         max_steer_angle = params["max_steer_angle"]
@@ -205,16 +204,15 @@ class SimpleVehicle(StateSpaceModel):
         aero_model = self.get_submodel("aero")
 
         # FIXME: we use some dummy inputs for speed evaluation only for now.
-        aero_inputs = aero_model.make_vector(
-            "inputs", front_ride_height=vx, rear_ride_height=vy, yaw=yaw_rate,
-        )
+        aero_inputs = dict(front_ride_height=vx, rear_ride_height=vy, yaw=yaw_rate)
 
         # FIXME: aero sign convention
         aero_return = self.get_submodel("aero").forward(aero_inputs)
         aero_coeff = aero_return.outputs
-        aero_forces = aero_coeff * (0.5 * air_density * (vx ** 2 + vy ** 2))
 
-        Fz_total = vehicle_mass * gravity + aero_forces[Vector3dEnum.Z]
+        Fz_total = vehicle_mass * gravity + aero_coeff["Cz"] * (
+            0.5 * air_density * (vx ** 2 + vy ** 2)
+        )
 
         # Compute tire load
         # TODO: currently we ignore
@@ -292,10 +290,7 @@ class SimpleVehicle(StateSpaceModel):
             slips["slip_ratio_" + c] = kappa
             slips["slip_angle_" + c] = alpha
 
-            tire_model = self.get_submodel("tire_" + c)
-
-            inputs = tire_model.make_vector(
-                group="inputs",
+            inputs = dict(
                 Fz=wheel_load[c],
                 kappa=kappa,
                 alpha=alpha * mirror_coeff[c],
@@ -303,15 +298,10 @@ class SimpleVehicle(StateSpaceModel):
                 gamma=0.0 * mirror_coeff[c],  # TODO: hardcoded for now
             )
 
-            outputs = tire_model.forward(inputs).outputs
-
+            outputs = self.get_submodel("tire_" + c).forward(inputs).outputs
             # TODO: tire moments are not taken into account yet.
             tire_force_in_wheel_coordinate[c] = lnp.array(
-                [
-                    tire_model.get_output(outputs, "Fx"),
-                    tire_model.get_output(outputs, "Fy") * mirror_coeff[c],
-                    wheel_load[c],
-                ]
+                [outputs["Fx"], outputs["Fy"] * mirror_coeff[c], wheel_load[c],]
             )
 
         # Transform tire forces to body coordinate
@@ -328,7 +318,9 @@ class SimpleVehicle(StateSpaceModel):
 
         # aero force in body coordinate
         # FIXME: drag should be absolute speed
-        drag = lnp.array([-aero_forces[Vector3dEnum.X], 0, 0])
+        drag = lnp.array(
+            [-aero_coeff["Cx"] * (0.5 * air_density * (vx ** 2 + vy ** 2)), 0, 0]
+        )
 
         # Sum up all the forces
         total_force_on_body = reduce(add, tire_force_in_body_coordinate.values())
@@ -352,19 +344,17 @@ class SimpleVehicle(StateSpaceModel):
         vx_dot = ax + yaw_rate * vy
         vy_dot = ay - yaw_rate * vx
 
-        states_dot = self.make_vector(
-            group="states",
-            vx=vx_dot,
-            vy=vy_dot,
-            yaw_rate=yaw_accel,
-            wheel_speed_fl=wheel_speed_dot["fl"],
-            wheel_speed_fr=wheel_speed_dot["fr"],
-            wheel_speed_rl=wheel_speed_dot["rl"],
-            wheel_speed_rr=wheel_speed_dot["rr"],
+        states_dot = dict(
+            vx_dot=vx_dot,
+            vy_dot=vy_dot,
+            yaw_rate_dot=yaw_accel,
+            wheel_speed_fl_dot=wheel_speed_dot["fl"],
+            wheel_speed_fr_dot=wheel_speed_dot["fr"],
+            wheel_speed_rl_dot=wheel_speed_dot["rl"],
+            wheel_speed_rr_dot=wheel_speed_dot["rr"],
         )
 
-        outputs = self.make_vector(
-            group="outputs",
+        outputs = dict(
             ax=ax,
             ay=ay,
             drive_torque_rl=drive_torque_rl,
@@ -384,7 +374,7 @@ class SimpleVehicle(StateSpaceModel):
             **slips,
         )
 
-        residuals = self.make_vector(group="residuals", ax=ax - ax_in, ay=ay - ay_in)
+        residuals = dict(ax=ax - ax_in, ay=ay - ay_in)
         return self.make_state_space_model_return(
             states_dot=states_dot, outputs=outputs, residuals=residuals,
         )

--- a/lumos/simulations/laptime_simulation.py
+++ b/lumos/simulations/laptime_simulation.py
@@ -82,10 +82,10 @@ def get_default_scales() -> Tuple[ScaleConfig]:
         ScaleConfig("states", "wheel_speed_fr", 50.0),
         ScaleConfig("states", "wheel_speed_rl", 50.0),
         ScaleConfig("states", "wheel_speed_rr", 50.0),
-        ScaleConfig("states_dot", "wheel_speed_fl_dot", 50.0),
-        ScaleConfig("states_dot", "wheel_speed_fr_dot", 50.0),
-        ScaleConfig("states_dot", "wheel_speed_rl_dot", 50.0),
-        ScaleConfig("states_dot", "wheel_speed_rr_dot", 50.0),
+        ScaleConfig("states_dot", "wheel_speed_fl", 50.0),
+        ScaleConfig("states_dot", "wheel_speed_fr", 50.0),
+        ScaleConfig("states_dot", "wheel_speed_rl", 50.0),
+        ScaleConfig("states_dot", "wheel_speed_rr", 50.0),
     )
     return scales
 

--- a/lumos/simulations/laptime_simulation.py
+++ b/lumos/simulations/laptime_simulation.py
@@ -42,10 +42,13 @@ def get_default_bounds() -> Dict[str, Any]:
 
     # Limit the slip
     bounds += tuple(
-        BoundConfig("con_outputs", "slip_ratio_" + c, (-0.05, 0.05)) for c in _corners
+        BoundConfig("con_outputs", "vehicle.slip_ratio_" + c, (-0.05, 0.05))
+        for c in _corners
     )
     bounds += tuple(
-        BoundConfig("con_outputs", "slip_angle_" + c, (-np.deg2rad(5), np.deg2rad(5)))
+        BoundConfig(
+            "con_outputs", "vehicle.slip_angle_" + c, (-np.deg2rad(5), np.deg2rad(5))
+        )
         for c in _corners
     )
 

--- a/tests/test_models/test_aero/test_aero.py
+++ b/tests/test_models/test_aero/test_aero.py
@@ -13,12 +13,14 @@ class TestConstAero(BaseModelTest, unittest.TestCase):
     ModelClass: type = ConstAero
 
     def test_outputs_are_correct(self):
-        inputs = self.model.make_random_vector("inputs")
+        inputs = dict(
+            zip(self.model.names.inputs, self.model.make_random_vector("inputs"))
+        )
         model_return = self.model.forward(inputs)
 
-        expected_outputs = self.model.make_vector("outputs", **self.model._params)
-
-        np.testing.assert_allclose(model_return.outputs, expected_outputs)
+        # Check constant values are the same as in the params
+        for k, v in model_return.outputs.items():
+            self.assertAlmostEqual(v, self.model._params[k])
 
 
 class TestGPAero(BaseModelTest, unittest.TestCase):

--- a/tests/test_models/test_base_model.py
+++ b/tests/test_models/test_base_model.py
@@ -171,7 +171,7 @@ AY = 8.0
 @state_space_io(
     states=("vx", "vy"), inputs=("throttle", "steer", "brake"), outputs=("ax", "ay"),
 )
-class TestVehicle(StateSpaceModel):
+class VehicleForTest(StateSpaceModel):
     _submodel_names = ("powertrain", "tire")
 
     @classmethod
@@ -290,7 +290,7 @@ class SimpleEngineWithNoOutputs(Model):
 
 class TestOutputsCollection(unittest.TestCase):
     types = [
-        TestVehicle,
+        VehicleForTest,
         HybridPowertrain,
         MF72,
         SimpleEMotor,
@@ -309,13 +309,13 @@ class TestOutputsCollection(unittest.TestCase):
             ModelMaker.remove_from_registry(model_type)
 
     def test_output_names_are_correctly_setup_after_constructions(self):
-        base_config = ModelMaker.make_config("TestVehicle")
+        base_config = ModelMaker.make_config("VehicleForTest")
         base_model = ModelMaker.make_model_from_config(base_config)
 
         self.assertIn("powertrain.engine.power", base_model.names.outputs)
 
         # Make sure things still work when some model doesn't have an output
-        variant1_config = ModelMaker.make_config("TestVehicle")
+        variant1_config = ModelMaker.make_config("VehicleForTest")
         variant1_config.replace_subtree(
             "powertrain.engine", ModelMaker.make_config("SimpleEngineWithNoOutputs")
         )
@@ -330,7 +330,7 @@ class TestOutputsCollection(unittest.TestCase):
         )
 
     def test_output_values_are_correctly_set_after_execution(self):
-        base_config = ModelMaker.make_config("TestVehicle")
+        base_config = ModelMaker.make_config("VehicleForTest")
         base_model = ModelMaker.make_model_from_config(base_config)
 
         states = base_model.make_const_dict("states", 0.1)

--- a/tests/test_models/test_base_model.py
+++ b/tests/test_models/test_base_model.py
@@ -15,8 +15,8 @@ from lumos.models.drone_model import DroneModel
 )
 class ModelWithWrongConOutputs(StateSpaceModel):
     def forward(self, states, inputs, mesh=0.0):
-        states_dot = self.make_vector(group="states", state0=0.0, state1=0.1)
-        outputs = self.make_vector(group="outputs", output0=0.0, output1=1.0)
+        states_dot = self.make_dict(group="states", state0=0.0, state1=0.1)
+        outputs = self.make_dict(group="outputs", output0=0.0, output1=1.0)
 
         return self.make_state_space_model_return(
             states_dot=states_dot, outputs=outputs,
@@ -45,7 +45,7 @@ class ModelWithNoConOutputs(ModelWithCorrectConOutputs):
 )
 class ModelWithNoOutputs(StateSpaceModel):
     def forward(self, states, inputs, mesh=0.0):
-        states_dot = self.make_vector(group="states", state0=0.0, state1=0.1)
+        states_dot = self.make_dict(group="states", state0=0.0, state1=0.1)
 
         return self.make_state_space_model_return(states_dot=states_dot,)
 
@@ -133,13 +133,8 @@ class TestStateSpaceModel(unittest.TestCase):
         inputs = np.zeros(model_correct.num_inputs)
         model_return = model_correct.forward(states, inputs)
 
-        manually_extracted = np.array(
-            [
-                model_correct.get_output(model_return.outputs, n)
-                for n in model_correct.get_group_names("con_outputs")
-            ]
-        )
-        np.testing.assert_allclose(model_return.con_outputs, manually_extracted)
+        for k, v in model_return.con_outputs.items():
+            self.assertAlmostEqual(v, model_return.outputs[k])
 
         # When conoutputs are empty
         model_no_cons = ModelWithNoConOutputs()

--- a/tests/test_models/test_base_model.py
+++ b/tests/test_models/test_base_model.py
@@ -204,7 +204,7 @@ class TestVehicle(StateSpaceModel):
 
         # Make some dummy outputs
         outputs = self.make_dict("outputs", ax=AX, ay=AY, **submodel_outputs)
-        states_dot = self.make_dict("states_dot", vx_dot=0.1, vy_dot=0.2)
+        states_dot = self.make_dict("states_dot", vx=0.1, vy=0.2)
         return self.make_state_space_model_return(
             states_dot=states_dot, outputs=outputs
         )
@@ -227,7 +227,7 @@ class HybridPowertrain(StateSpaceModel):
         engine_ratio = 0.8
 
         # Assemble states_dot vector with dummy values
-        states_dot = self.make_dict("states_dot", engine_speed_dot=-25.0)
+        states_dot = self.make_dict("states_dot", engine_speed=-25.0)
 
         # Call engine
         engine_model = self.get_submodel("engine")

--- a/tests/test_models/test_base_model.py
+++ b/tests/test_models/test_base_model.py
@@ -1,9 +1,15 @@
 import unittest
-from copy import deepcopy
 
 import numpy as np
 
-from lumos.models.base import StateSpaceModel, state_space_io
+from lumos.models.composition import ModelMaker
+from lumos.models.base import (
+    StateSpaceModel,
+    state_space_io,
+    Model,
+    model_io,
+    ModelReturn,
+)
 from lumos.models.drone_model import DroneModel
 
 
@@ -150,3 +156,199 @@ class TestStateSpaceModel(unittest.TestCase):
         self.assertEqual(len(model_return.states_dot), model.num_states)
         self.assertEqual(len(model_return.outputs), 0)
         self.assertEqual(len(model_return.con_outputs), 0)
+
+
+ENGINE_TORQUE = 1.0
+ENGINE_POWER = 2.0
+EMOTOR_TORQUE = 3.0
+EMOTOR_POWER = 4.0
+TOTAL_POWER = 5.0
+TOTAL_TORQUE = 6.0
+AX = 7.0
+AY = 8.0
+
+
+@state_space_io(
+    states=("vx", "vy"), inputs=("throttle", "steer", "brake"), outputs=("ax", "ay"),
+)
+class TestVehicle(StateSpaceModel):
+    _submodel_names = ("powertrain", "tire")
+
+    @classmethod
+    def get_default_submodel_config(cls):
+        return {"powertrain": "HybridPowertrain", "tire": "MF72"}
+
+    def forward(self, states, inputs, mesh):
+        vx = states["vx"]
+        throttle = inputs["throttle"]
+
+        # Call powertrain model
+        powertrain_model = self.get_submodel("powertrain")
+        powertrain_inputs = powertrain_model.make_dict("inputs", demand=throttle)
+        powertrain_states = powertrain_model.make_dict(
+            "states", engine_speed=vx / 100.0
+        )
+
+        powertrain_return = powertrain_model.forward(
+            powertrain_states, powertrain_inputs, 0.0
+        )
+
+        # Call tire model
+        tire_model = self.get_submodel("tire")
+        tire_inputs = tire_model.make_const_dict("inputs", 0.3)
+        tire_return = tire_model.forward(tire_inputs)
+
+        submodel_outputs = self.combine_submodel_outputs(
+            powertrain=powertrain_return.outputs, tire=tire_return.outputs,
+        )
+
+        # Make some dummy outputs
+        outputs = self.make_dict("outputs", ax=AX, ay=AY, **submodel_outputs)
+        states_dot = self.make_dict("states_dot", vx_dot=0.1, vy_dot=0.2)
+        return self.make_state_space_model_return(
+            states_dot=states_dot, outputs=outputs
+        )
+
+
+@state_space_io(
+    states=("engine_speed",),
+    inputs=("demand",),
+    outputs=("total_power", "total_torque"),
+)
+class HybridPowertrain(StateSpaceModel):
+    _submodel_names = ("engine", "emotor")
+
+    @classmethod
+    def get_default_submodel_config(cls):
+        return {"engine": "SimpleEngine", "emotor": "SimpleEMotor"}
+
+    def forward(self, states, inputs, mesh):
+        demand = inputs["demand"]
+        engine_ratio = 0.8
+
+        # Assemble states_dot vector with dummy values
+        states_dot = self.make_dict("states_dot", engine_speed_dot=-25.0)
+
+        # Call engine
+        engine_model = self.get_submodel("engine")
+        engine_inputs = engine_model.make_dict("inputs", demand=demand * engine_ratio)
+        engine_return = engine_model.forward(engine_inputs)
+
+        # Call e-motor
+        emotor_model = self.get_submodel("emotor")
+        emotor_inputs = emotor_model.make_dict(
+            "inputs", demand=(1 - demand) * engine_ratio
+        )
+        emotor_return = emotor_model.forward(emotor_inputs)
+
+        # Combine all submodel outputs into a flattened dictionary
+        submodel_outputs = self.combine_submodel_outputs(
+            engine=engine_return.outputs, emotor=emotor_return.outputs,
+        )
+
+        # Use direct current model outputs and flattened submodel outputs to form the
+        # combined outputs vector.
+        outputs = self.make_dict(
+            "outputs",
+            total_power=TOTAL_POWER,
+            total_torque=TOTAL_TORQUE,
+            **submodel_outputs
+        )
+        return self.make_state_space_model_return(
+            outputs=outputs, states_dot=states_dot
+        )
+
+
+@model_io(inputs=("long_slip", "lat_slip"), outputs=("Fx", "Fy"))
+class MF72(Model):
+    def forward(self, inputs):
+        outputs = self.make_dict(
+            "outputs", Fx=inputs["long_slip"] * 1000, Fy=inputs["lat_slip"] * 1000
+        )
+        return ModelReturn(outputs=outputs)
+
+
+@model_io(inputs=("demand",), outputs=("torque", "power"))
+class SimpleEMotor(Model):
+    def forward(self, inputs):
+        outputs = self.make_dict("outputs", torque=EMOTOR_TORQUE, power=EMOTOR_POWER)
+        return ModelReturn(outputs=outputs)
+
+
+@model_io(inputs=("demand",), outputs=("torque", "power"))
+class SimpleEngine(Model):
+    def forward(self, inputs):
+        outputs = self.make_dict("outputs", torque=ENGINE_TORQUE, power=ENGINE_POWER)
+        return ModelReturn(outputs=outputs)
+
+
+@model_io(inputs=("demand",))
+class SimpleEngineWithNoOutputs(Model):
+    def forward(self, inputs):
+        return ModelReturn()
+
+
+class TestOutputsCollection(unittest.TestCase):
+    types = [
+        TestVehicle,
+        HybridPowertrain,
+        MF72,
+        SimpleEMotor,
+        SimpleEngine,
+        SimpleEngineWithNoOutputs,
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        for model_type in cls.types:
+            ModelMaker.add_to_registry(model_type)
+
+    @classmethod
+    def tearDownClass(cls):
+        for model_type in cls.types:
+            ModelMaker.remove_from_registry(model_type)
+
+    def test_output_names_are_correctly_setup_after_constructions(self):
+        base_config = ModelMaker.make_config("TestVehicle")
+        base_model = ModelMaker.make_model_from_config(base_config)
+
+        self.assertIn("powertrain.engine.power", base_model.names.outputs)
+
+        # Make sure things still work when some model doesn't have an output
+        variant1_config = ModelMaker.make_config("TestVehicle")
+        variant1_config.replace_subtree(
+            "powertrain.engine", ModelMaker.make_config("SimpleEngineWithNoOutputs")
+        )
+        variant1_model = ModelMaker.make_model_from_config(variant1_config)
+        self.assertNotIn("powertrain.engine.power", variant1_model.names.outputs)
+
+        # Check that there are no duplicates
+        self.assertEqual(
+            len(set(base_model.names.outputs)),
+            len(base_model.names.outputs),
+            msg="Duplicates detected in model output names",
+        )
+
+    def test_output_values_are_correctly_set_after_execution(self):
+        base_config = ModelMaker.make_config("TestVehicle")
+        base_model = ModelMaker.make_model_from_config(base_config)
+
+        states = base_model.make_const_dict("states", 0.1)
+        inputs = base_model.make_const_dict("inputs", 0.5)
+
+        base_model_return = base_model.forward(states, inputs, 0.0)
+        outputs = base_model_return.outputs
+
+        # Check grand children outputs
+        self.assertAlmostEqual(outputs["powertrain.engine.power"], ENGINE_POWER)
+        self.assertAlmostEqual(outputs["powertrain.engine.torque"], ENGINE_TORQUE)
+        self.assertAlmostEqual(outputs["powertrain.emotor.power"], EMOTOR_POWER)
+        self.assertAlmostEqual(outputs["powertrain.emotor.torque"], EMOTOR_TORQUE)
+
+        # Check child outputs
+        self.assertAlmostEqual(outputs["powertrain.total_power"], TOTAL_POWER)
+        self.assertAlmostEqual(outputs["powertrain.total_torque"], TOTAL_TORQUE)
+
+        # Check top level outputs
+        self.assertAlmostEqual(outputs["ax"], AX)
+        self.assertAlmostEqual(outputs["ay"], AY)

--- a/tests/test_models/test_kinematics.py
+++ b/tests/test_models/test_kinematics.py
@@ -38,7 +38,7 @@ class TestTrackPosition2D(BaseStateSpaceModelTest, unittest.TestCase):
             model_return = self.model.forward(states=states, inputs=inputs)
 
             for k in states:
-                states[k] += model_return.states_dot[k + "_dot"] * distance_step
+                states[k] += model_return.states_dot[k] * distance_step
 
         # Call the model again on the final states to ensure the outputs and states are
         # sync'd

--- a/tests/test_models/test_simlpe_vehicle_on_track.py
+++ b/tests/test_models/test_simlpe_vehicle_on_track.py
@@ -1,3 +1,4 @@
+from mimetypes import init
 import unittest
 
 import numpy as np
@@ -15,7 +16,7 @@ class TestSimpleVehicleOnTrack(BaseStateSpaceModelTest, unittest.TestCase):
         # FIXME: this is really bad. How do we get the rolling radius estimate?
         no_slip_omega = vx / 0.33
 
-        return self.model.make_vector(
+        return self.model.make_dict(
             group="states",
             time=0,
             n=0,
@@ -31,7 +32,7 @@ class TestSimpleVehicleOnTrack(BaseStateSpaceModelTest, unittest.TestCase):
 
     def test_turn_left(self):
         init_states = self._get_initial_states()
-        inputs = self.model.make_vector(
+        inputs = self.model.make_dict(
             group="inputs",
             throttle=0.0,
             brake=0,
@@ -45,9 +46,9 @@ class TestSimpleVehicleOnTrack(BaseStateSpaceModelTest, unittest.TestCase):
         model_return = self.model.forward(init_states, inputs, mesh=0.0)
 
         # should directly get +ve lateral acceleration, +ve yaw acceleration and derivative of vy
-        self.assertGreater(self.model.get_state(model_return.states_dot, "vy"), 0)
-        self.assertGreater(self.model.get_state(model_return.states_dot, "yaw_rate"), 0)
-        self.assertGreater(self.model.get_output(model_return.outputs, "ay"), 0)
+        self.assertGreater(model_return.states_dot["vy_dot"], 0)
+        self.assertGreater(model_return.states_dot["yaw_rate_dot"], 0)
+        self.assertGreater(model_return.outputs["vehicle.ay"], 0)
 
         # After a few timesteps:
         # The speed should decelerate due to cornering resistance
@@ -57,41 +58,33 @@ class TestSimpleVehicleOnTrack(BaseStateSpaceModelTest, unittest.TestCase):
         num_steps = 21
         dist_step = 1.0
 
-        # Careful, numpy arrays are mutable!
-        states = np.copy(init_states)
-        distance = 0.0
-        for _ in range(num_steps):
-            model_return = self.model.forward(states, inputs, mesh=distance)
-            states += model_return.states_dot * dist_step
-            distance += dist_step
+        states, outputs = self._forward_euler(init_states, inputs, dist_step, num_steps)
 
-        self.assertLess(
-            self.model.get_state(states, "vx"), self.model.get_state(init_states, "vx")
-        )
-        self.assertLess(self.model.get_state(states, "vy"), 0)
-        self.assertGreater(self.model.get_state(states, "yaw_rate"), 0)
+        self.assertLess(states["vx"], init_states["vx"])
+        self.assertLess(states["vy"], 0)
+        self.assertGreater(states["yaw_rate"], 0)
 
         # Assert position states
         self.assertGreater(
-            self.model.get_output(model_return.outputs, "yaw_angle"),
+            outputs["kinematics.yaw_angle"],
             0,
             msg="Yaw angle should be positive for turning left",
         )
 
         self.assertGreater(
-            self.model.get_state(states, "n"),
+            states["n"],
             0,
             msg="Distance across should be positive for turning left on straightline track",
         )
 
         self.assertGreater(
-            self.model.get_state(states, "time"),
+            states["time"],
             0,
             msg="Time used should be positive for turning left on straightline track",
         )
 
         self.assertLess(
-            distance,
-            self.model.get_state(init_states, "vx") * dist_step * num_steps,
+            dist_step * num_steps,
+            init_states["vx"] * dist_step * num_steps,
             msg="Distance travelled should be less than going straight from the start",
         )

--- a/tests/test_models/test_simlpe_vehicle_on_track.py
+++ b/tests/test_models/test_simlpe_vehicle_on_track.py
@@ -46,8 +46,8 @@ class TestSimpleVehicleOnTrack(BaseStateSpaceModelTest, unittest.TestCase):
         model_return = self.model.forward(init_states, inputs, mesh=0.0)
 
         # should directly get +ve lateral acceleration, +ve yaw acceleration and derivative of vy
-        self.assertGreater(model_return.states_dot["vy_dot"], 0)
-        self.assertGreater(model_return.states_dot["yaw_rate_dot"], 0)
+        self.assertGreater(model_return.states_dot["vy"], 0)
+        self.assertGreater(model_return.states_dot["yaw_rate"], 0)
         self.assertGreater(model_return.outputs["vehicle.ay"], 0)
 
         # After a few timesteps:

--- a/tests/test_models/test_simple_vehicle.py
+++ b/tests/test_models/test_simple_vehicle.py
@@ -15,8 +15,7 @@ class TestSimpleVehicle(BaseStateSpaceModelTest, unittest.TestCase):
         yaw_rate = 0.0
         no_slip_omega = vx / self.model._params["rolling_radius"]
 
-        return self.model.make_vector(
-            group="states",
+        return dict(
             vx=vx,
             vy=vy,
             yaw_rate=yaw_rate,
@@ -38,19 +37,13 @@ class TestSimpleVehicle(BaseStateSpaceModelTest, unittest.TestCase):
 
     def test_accel_straight(self):
         init_states = self._get_initial_states()
-        inputs = self.model.make_vector(
-            group="inputs", throttle=0.6, brake=0, steer=0, ax=0, ay=0
-        )
+        inputs = dict(throttle=0.6, brake=0, steer=0, ax=0, ay=0)
 
         model_return = self.model.forward(init_states, inputs)
 
         # Rear wheel should accelerate
-        self.assertGreater(
-            self.model.get_state(model_return.states_dot, "wheel_speed_rl"), 0
-        )
-        self.assertGreater(
-            self.model.get_state(model_return.states_dot, "wheel_speed_rr"), 0
-        )
+        self.assertGreater(model_return.states_dot["wheel_speed_rl"], 0)
+        self.assertGreater(model_return.states_dot["wheel_speed_rr"], 0)
 
         # After a few timesteps, the vehicle should be faster and still driving straight
         num_steps = 21
@@ -59,6 +52,7 @@ class TestSimpleVehicle(BaseStateSpaceModelTest, unittest.TestCase):
         # Careful, numpy arrays are mutable!
         states = np.copy(init_states)
         for _ in range(num_steps):
+            breakpoint()
             model_return = self.model.forward(states, inputs)
             states += model_return.states_dot * time_step
 
@@ -74,9 +68,7 @@ class TestSimpleVehicle(BaseStateSpaceModelTest, unittest.TestCase):
 
     def test_brake_straight(self):
         init_states = self._get_initial_states()
-        inputs = self.model.make_vector(
-            group="inputs", throttle=0.0, brake=0.1, steer=0, ax=0, ay=0
-        )
+        inputs = dict(throttle=0.0, brake=0.1, steer=0, ax=0, ay=0)
 
         model_return = self.model.forward(init_states, inputs)
 
@@ -108,9 +100,7 @@ class TestSimpleVehicle(BaseStateSpaceModelTest, unittest.TestCase):
 
     def test_turn_left(self):
         init_states = self._get_initial_states()
-        inputs = self.model.make_vector(
-            group="inputs", throttle=0.0, brake=0, steer=0.2, ax=0, ay=0
-        )
+        inputs = dict(throttle=0.0, brake=0, steer=0.2, ax=0, ay=0)
 
         model_return = self.model.forward(init_states, inputs)
 
@@ -143,9 +133,7 @@ class TestSimpleVehicle(BaseStateSpaceModelTest, unittest.TestCase):
 
     def test_turn_right(self):
         init_states = self._get_initial_states()
-        inputs = self.model.make_vector(
-            group="inputs", throttle=0.0, brake=0, steer=-0.2, ax=0, ay=0
-        )
+        inputs = dict(throttle=0.0, brake=0, steer=-0.2, ax=0, ay=0)
 
         model_return = self.model.forward(init_states, inputs)
 
@@ -186,9 +174,7 @@ class TestSimpleVehicle(BaseStateSpaceModelTest, unittest.TestCase):
                 self.model.get_var_index("states", "wheel_speed_rl")
             ] = wheel_speed_rl
 
-            inputs = self.model.make_vector(
-                group="inputs", throttle=0.3, brake=0, steer=0.0, ax=0, ay=0
-            )
+            inputs = dict(throttle=0.3, brake=0, steer=0.0, ax=0, ay=0)
 
             model_return = self.model.forward(states, inputs)
             delta_torque = self.model.get_output(

--- a/tests/test_models/test_simple_vehicle.py
+++ b/tests/test_models/test_simple_vehicle.py
@@ -42,8 +42,8 @@ class TestSimpleVehicle(BaseStateSpaceModelTest, unittest.TestCase):
         model_return = self.model.forward(init_states, inputs)
 
         # Rear wheel should accelerate
-        self.assertGreater(model_return.states_dot["wheel_speed_rl_dot"], 0)
-        self.assertGreater(model_return.states_dot["wheel_speed_rr_dot"], 0)
+        self.assertGreater(model_return.states_dot["wheel_speed_rl"], 0)
+        self.assertGreater(model_return.states_dot["wheel_speed_rr"], 0)
 
         # After a few timesteps, the vehicle should be faster and still driving straight
         num_steps = 21
@@ -68,7 +68,7 @@ class TestSimpleVehicle(BaseStateSpaceModelTest, unittest.TestCase):
 
         # All wheels should decelerate
         for c in ("fl", "fr", "rl", "rr"):
-            self.assertLess(model_return.states_dot[f"wheel_speed_{c}_dot"], 0)
+            self.assertLess(model_return.states_dot[f"wheel_speed_{c}"], 0)
 
         # After a few timesteps, the vehicle should be slower and still driving straight
         num_steps = 21
@@ -91,8 +91,8 @@ class TestSimpleVehicle(BaseStateSpaceModelTest, unittest.TestCase):
         model_return = self.model.forward(init_states, inputs)
 
         # should directly get +ve lateral acceleration, +ve yaw acceleration and derivative of vy
-        self.assertGreater(model_return.states_dot["vy_dot"], 0)
-        self.assertGreater(model_return.states_dot["yaw_rate_dot"], 0)
+        self.assertGreater(model_return.states_dot["vy"], 0)
+        self.assertGreater(model_return.states_dot["yaw_rate"], 0)
         self.assertGreater(model_return.outputs["ay"], 0)
 
         # After a few timesteps:
@@ -118,8 +118,8 @@ class TestSimpleVehicle(BaseStateSpaceModelTest, unittest.TestCase):
         model_return = self.model.forward(init_states, inputs)
 
         # should directly get +ve lateral acceleration, +ve yaw acceleration and derivative of vy
-        self.assertLess(model_return.states_dot["vy_dot"], 0)
-        self.assertLess(model_return.states_dot["yaw_rate_dot"], 0)
+        self.assertLess(model_return.states_dot["vy"], 0)
+        self.assertLess(model_return.states_dot["yaw_rate"], 0)
         self.assertLess(model_return.outputs["ay"], 0)
 
         num_steps = 21

--- a/tests/test_models/test_simple_vehicle.py
+++ b/tests/test_models/test_simple_vehicle.py
@@ -42,29 +42,23 @@ class TestSimpleVehicle(BaseStateSpaceModelTest, unittest.TestCase):
         model_return = self.model.forward(init_states, inputs)
 
         # Rear wheel should accelerate
-        self.assertGreater(model_return.states_dot["wheel_speed_rl"], 0)
-        self.assertGreater(model_return.states_dot["wheel_speed_rr"], 0)
+        self.assertGreater(model_return.states_dot["wheel_speed_rl_dot"], 0)
+        self.assertGreater(model_return.states_dot["wheel_speed_rr_dot"], 0)
 
         # After a few timesteps, the vehicle should be faster and still driving straight
         num_steps = 21
         time_step = 0.05
 
         # Careful, numpy arrays are mutable!
-        states = np.copy(init_states)
-        for _ in range(num_steps):
-            breakpoint()
-            model_return = self.model.forward(states, inputs)
-            states += model_return.states_dot * time_step
+        states, outputs = self._forward_euler(init_states, inputs, time_step, num_steps)
 
         # Speed should have increased
         # TODO: should we put a threshold on 'sufficient increase'?
-        self.assertGreater(
-            self.model.get_state(states, "vx"), self.model.get_state(init_states, "vx")
-        )
+        self.assertGreater(states["vx"], init_states["vx"])
 
         # lateral speed and yaw rate should stay at 0
-        self.assertAlmostEqual(self.model.get_state(states, "vy"), 0)
-        self.assertAlmostEqual(self.model.get_state(states, "yaw_rate"), 0)
+        self.assertAlmostEqual(states["vy"], 0)
+        self.assertAlmostEqual(states["yaw_rate"], 0)
 
     def test_brake_straight(self):
         init_states = self._get_initial_states()
@@ -74,29 +68,21 @@ class TestSimpleVehicle(BaseStateSpaceModelTest, unittest.TestCase):
 
         # All wheels should decelerate
         for c in ("fl", "fr", "rl", "rr"):
-            self.assertLess(
-                self.model.get_state(model_return.states_dot, f"wheel_speed_{c}"), 0
-            )
+            self.assertLess(model_return.states_dot[f"wheel_speed_{c}_dot"], 0)
 
         # After a few timesteps, the vehicle should be slower and still driving straight
         num_steps = 21
         time_step = 0.05
 
-        # Careful, numpy arrays are mutable!
-        states = np.copy(init_states)
-        for _ in range(num_steps):
-            model_return = self.model.forward(states, inputs)
-            states += model_return.states_dot * time_step
+        states, outputs = self._forward_euler(init_states, inputs, time_step, num_steps)
 
         # Speed should have increased
         # TODO: should we put a threshold on 'sufficient increase'?
-        self.assertLess(
-            self.model.get_state(states, "vx"), self.model.get_state(init_states, "vx")
-        )
+        self.assertLess(states["vx"], init_states["vx"])
 
         # lateral speed and yaw rate should stay at 0
-        self.assertAlmostEqual(self.model.get_state(states, "vy"), 0)
-        self.assertAlmostEqual(self.model.get_state(states, "yaw_rate"), 0)
+        self.assertAlmostEqual(states["vy"], 0)
+        self.assertAlmostEqual(states["yaw_rate"], 0)
 
     def test_turn_left(self):
         init_states = self._get_initial_states()
@@ -105,9 +91,9 @@ class TestSimpleVehicle(BaseStateSpaceModelTest, unittest.TestCase):
         model_return = self.model.forward(init_states, inputs)
 
         # should directly get +ve lateral acceleration, +ve yaw acceleration and derivative of vy
-        self.assertGreater(self.model.get_state(model_return.states_dot, "vy"), 0)
-        self.assertGreater(self.model.get_state(model_return.states_dot, "yaw_rate"), 0)
-        self.assertGreater(self.model.get_output(model_return.outputs, "ay"), 0)
+        self.assertGreater(model_return.states_dot["vy_dot"], 0)
+        self.assertGreater(model_return.states_dot["yaw_rate_dot"], 0)
+        self.assertGreater(model_return.outputs["ay"], 0)
 
         # After a few timesteps:
         # The speed should decelerate due to cornering resistance
@@ -117,17 +103,11 @@ class TestSimpleVehicle(BaseStateSpaceModelTest, unittest.TestCase):
         num_steps = 21
         time_step = 0.05
 
-        # Careful, numpy arrays are mutable!
-        states = np.copy(init_states)
-        for _ in range(num_steps):
-            model_return = self.model.forward(states, inputs)
-            states += model_return.states_dot * time_step
+        states, outputs = self._forward_euler(init_states, inputs, time_step, num_steps)
 
-        self.assertLess(
-            self.model.get_state(states, "vx"), self.model.get_state(init_states, "vx")
-        )
-        self.assertLess(self.model.get_state(states, "vy"), 0)
-        self.assertGreater(self.model.get_state(states, "yaw_rate"), 0)
+        self.assertLess(states["vx"], init_states["vx"])
+        self.assertLess(states["vy"], 0)
+        self.assertGreater(states["yaw_rate"], 0)
 
         # TODO: we could also check that the vehicle gets into kind of a steady-state turn
 
@@ -138,48 +118,42 @@ class TestSimpleVehicle(BaseStateSpaceModelTest, unittest.TestCase):
         model_return = self.model.forward(init_states, inputs)
 
         # should directly get +ve lateral acceleration, +ve yaw acceleration and derivative of vy
-        self.assertLess(self.model.get_state(model_return.states_dot, "vy"), 0)
-        self.assertLess(self.model.get_state(model_return.states_dot, "yaw_rate"), 0)
-        self.assertLess(self.model.get_output(model_return.outputs, "ay"), 0)
+        self.assertLess(model_return.states_dot["vy_dot"], 0)
+        self.assertLess(model_return.states_dot["yaw_rate_dot"], 0)
+        self.assertLess(model_return.outputs["ay"], 0)
 
         num_steps = 21
         time_step = 0.05
 
-        # Careful, numpy arrays are mutable!
-        states = np.copy(init_states)
-        for _ in range(num_steps):
-            model_return = self.model.forward(states, inputs)
-            states += model_return.states_dot * time_step
+        states, outputs = self._forward_euler(init_states, inputs, time_step, num_steps)
 
         # All the other assertions change sign compared to left turn, except for this one
-        self.assertLess(
-            self.model.get_state(states, "vx"), self.model.get_state(init_states, "vx")
-        )
-        self.assertGreater(self.model.get_state(states, "vy"), 0)
-        self.assertLess(self.model.get_state(states, "yaw_rate"), 0)
+        self.assertLess(states["vx"], init_states["vx"])
+        self.assertGreater(states["vy"], 0)
+        self.assertLess(states["yaw_rate"], 0)
 
     def test_delta_torque(self):
         """When there is a delta speed
         There is a delta torque of the opposite sign.
         """
 
-        # Use an np array as states because we want it mutable
-        states = np.array(self._get_initial_states())
-        wheel_speed_rr = self.model.get_state(states, "wheel_speed_rr")
+        states = self._get_initial_states()
+        wheel_speed_rr = states["wheel_speed_rr"]
 
         for delta_speed in [-1.0, 1.0]:
             wheel_speed_rl = wheel_speed_rr + delta_speed
 
-            states[
-                self.model.get_var_index("states", "wheel_speed_rl")
-            ] = wheel_speed_rl
+            states["wheel_speed_rl"] = wheel_speed_rl
 
-            inputs = dict(throttle=0.3, brake=0, steer=0.0, ax=0, ay=0)
+            inputs = self.model.make_dict(
+                "inputs", throttle=0.3, brake=0, steer=0.0, ax=0, ay=0
+            )
 
             model_return = self.model.forward(states, inputs)
-            delta_torque = self.model.get_output(
-                model_return.outputs, "drive_torque_rl"
-            ) - self.model.get_output(model_return.outputs, "drive_torque_rr")
+            delta_torque = (
+                model_return.outputs["drive_torque_rl"]
+                - model_return.outputs["drive_torque_rr"]
+            )
 
             # delta speed and torque should be opposite signs
             self.assertLess(delta_speed * delta_torque, 0.0)

--- a/tests/test_models/test_tires/test_pacejka.py
+++ b/tests/test_models/test_tires/test_pacejka.py
@@ -66,7 +66,7 @@ class TestMF52Outputs(unittest.TestCase):
 
         # Nxm matrix: N vectors with each vector size m
         inputs = np.array(list(itertools.product(*val_list)))
-        outputs, *_ = lmap(self.model.forward)(inputs)
+        outputs, *_ = lmap(self.model.forward_with_arrays)(inputs)
         return outputs
 
     def test_combined_load(self):

--- a/tests/test_models/test_tires/test_perantoni_tire.py
+++ b/tests/test_models/test_tires/test_perantoni_tire.py
@@ -16,17 +16,15 @@ class TestPerantoniTire(BaseModelTest, unittest.TestCase):
     def _get_fx_from_kappa(self, kappa: float, input_dict: Dict[str, float]) -> float:
         """Helper to perform longitudinal sweep"""
         input_dict["kappa"] = kappa
-        inputs = self.model.make_vector(group="inputs", **input_dict)
-        outputs, *_ = self.model.forward(inputs=inputs)
+        outputs, *_ = self.model.forward(inputs=input_dict)
 
-        return self.model.get_output(outputs, "Fx")
+        return outputs["Fx"]
 
     def _get_fy_from_alpha(self, alpha: float, input_dict: Dict[str, float]) -> float:
         input_dict["alpha"] = alpha
-        inputs = self.model.make_vector(group="inputs", **input_dict)
-        outputs, *_ = self.model.forward(inputs=inputs)
+        outputs, *_ = self.model.forward(inputs=input_dict)
 
-        return self.model.get_output(outputs, "Fy")
+        return outputs["Fy"]
 
     def test_pure_longitudinal(self):
         """Test characteristics in pure longitudinal load

--- a/tests/test_optimal_control/test_fixed_grid.py
+++ b/tests/test_optimal_control/test_fixed_grid.py
@@ -320,7 +320,9 @@ class TestLaptimeSimulationSolve(unittest.TestCase):
                 BoundaryConditionConfig(0, "states", "yaw_rate", 0.0),
                 BoundaryConditionConfig(-1, "states", "n", 0.0),
                 BoundaryConditionConfig(-1, "states", "eta", 0.0),
-                BoundaryConditionConfig(-1, "con_outputs", "slip_ratio_fl", 0.0),
+                BoundaryConditionConfig(
+                    -1, "con_outputs", "vehicle.slip_ratio_fl", 0.0
+                ),
             )
         cls.sim_config = LaptimeSimulation.get_sim_config(
             track="data/tracks/Catalunya.csv",


### PR DESCRIPTION
TODOS before merge:

- [x] add tests
- [x] fix the duplicate of `get_group_names` and `get_cls_group_names`
- [x] understand do we need all permutations of `apply_and_forward`, `apply_and_forward_with_arrays', `forward`, `forward_with_arrays`
- [x] currently `ModelReturn` and `StateSpaceModelReturn` are used with both arrays and dictionaries value for the entries, need to fix that
- [x] are there ways that we could help the user get better error messages for constructing inputs/outputs? eg, when a user requires an outpuname that doesn't exist, previously `self.get_input(inputs, "this_input")` would throw some meaningful error, but `inputs["this_input"]` would only throw key error -> moved to a new issue
- [x] can we/should we move `con_outputs` outside of model I/O? it is only needed for OCP, not really for models -> move to new issue -> moved to new issues
- [x] can we remove the `_dot` naming convention for states_dot?
- [ ] pause a bit before the merge, cool down and think about the design while working on something else
- [ ] update README
- [ ] update colab notebook (after release)