### PR TITLE
fix logging bugs

### DIFF
--- a/examples/drone_example.py
+++ b/examples/drone_example.py
@@ -1,6 +1,6 @@
 import logging
 import numpy as np
-
+from lumos.optimal_control.config import LoggingConfig
 from lumos.simulations.drone_simulation import DroneSimulation
 
 logger = logging.getLogger(__name__)
@@ -17,6 +17,9 @@ def main():
             backend="casadi",
             transcription="LGR",
             is_condensed=False,
+            logging_config=LoggingConfig(
+                sim_name="drone", results_dir="results", log_every_nth_iter=0
+            ),
         )
     )
 

--- a/examples/laptime_simulation_example.py
+++ b/examples/laptime_simulation_example.py
@@ -4,6 +4,7 @@ import os
 from lumos.models.composition import ModelMaker
 from lumos.models.simple_vehicle_on_track import SimpleVehicleOnTrack
 from lumos.models.tires.utils import create_params_from_tir_file
+from lumos.optimal_control.config import LoggingConfig
 from lumos.simulations.laptime_simulation import LaptimeSimulation
 
 logger = logging.getLogger(__name__)
@@ -26,13 +27,9 @@ def main():
         backend="casadi",
         track=track_file,
         transcription="LGR",
-        logging_config={
-            "results_dir": "results",  # store in a new directory at current directory
-            "sim_name": track,
-            "log_final_iter": False,
-            "log_metrics_history": False,
-            "log_every_nth_iter": 0,  # if 0, logging is off
-        },
+        logging_config=LoggingConfig(
+            sim_name=track, results_dir="results", log_every_nth_iter=0
+        ),
     )
 
     model_config = SimpleVehicleOnTrack.get_recursive_default_model_config()

--- a/lumos/optimal_control/config.py
+++ b/lumos/optimal_control/config.py
@@ -69,6 +69,15 @@ class TranscriptionConfig:
 
 
 @dataclass
+class LoggingConfig:
+    """Controls if and where the results as well as debug info are written to"""
+
+    sim_name: str = "simulation"
+    results_dir: str = "results"
+    log_every_nth_iter: int = 0
+
+
+@dataclass
 class SimConfig:
     """Simulation Configuraration for Optimal Control"""
 
@@ -82,7 +91,7 @@ class SimConfig:
     boundary_conditions: Tuple[BoundaryConditionConfig] = ()
     bounds: Tuple[BoundConfig] = ()
     scales: Tuple[ScaleConfig] = ()
-    logging_config: Dict[str, Any] = field(default_factory=dict)
+    logging_config: Optional[LoggingConfig] = None
 
     def __post_init__(self):
         # We allow a single string argument (with no additional arugments or relying on
@@ -92,15 +101,6 @@ class SimConfig:
         # transcription can have its own config.
         if isinstance(self.transcription, str):
             self.transcription = (self.transcription,)
-
-        if not self.logging_config:
-            self.logging_config = {
-                "results_dir": "results",  # store in a new directory at current directory
-                "sim_name": None,
-                "log_final_iter": False,
-                "log_metrics_history": False,
-                "log_every_nth_iter": 0,
-            }  # if 0, logging is off
 
         # Additional operations for desrialization for config fields
         if self.bounds and isinstance(self.bounds[0], dict):

--- a/lumos/optimal_control/fixed_mesh_ocp.py
+++ b/lumos/optimal_control/fixed_mesh_ocp.py
@@ -15,17 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class FixedMeshOCP(ScaledMeshOCP):
-    """Laptime simulation type of problem
-    - fixed grid
-    - distance grid instead of time
-
-    TODO: we could consider the following solutoin:
-    - a fixed mesh problem is just like a scaled_mesh_ocp, but with the bounds on the
-    mesh_scale varaible fixed.
-    - of course we would waste some computes as we have to compute more derivatives etc
-    for which we know actually would just be sparse (or actually not sparse but the
-    corresponding decision variable has no freedom.)
-    """
+    """Optimal Control problem where the mesh is fixed"""
 
     # No Global variables
     global_var_names = []

--- a/lumos/optimal_control/utils.py
+++ b/lumos/optimal_control/utils.py
@@ -290,6 +290,14 @@ class DecVarOperator:
     ) -> Union[float, lnp.ndarray]:
         return x[self.get_var_index_in_dec(group=group, name=name, stage=stage)]
 
+    def get_stage_var_array(self, x):
+        """Return an N x d array, for N stages and d variables per stage"""
+
+        return np.reshape(
+            x[: self.num_dec - self.num_global_var],
+            (self.num_stages, self.num_var_stage),
+        )
+
 
 def create_offset_structure(
     base_rows: List[int],

--- a/tests/test_optimal_control/test_ocp_logging.py
+++ b/tests/test_optimal_control/test_ocp_logging.py
@@ -1,3 +1,4 @@
+import itertools
 import glob
 import os
 import unittest
@@ -6,36 +7,91 @@ from tempfile import TemporaryDirectory
 import numpy as np
 import pandas as pd
 from pyarrow import parquet as pq
+from parameterized import parameterized
 
+from lumos.optimal_control.config import LoggingConfig
+from lumos.simulations.drone_simulation import DroneSimulation
 from lumos.simulations.laptime_simulation import LaptimeSimulation
 
 
 class TestOCPLogging(unittest.TestCase):
     num_iter: int = 5
+    SimClass: type = DroneSimulation
 
-    def test_logging(self):
+    def _run_and_log(
+        self,
+        results_dir: str,
+        log_every_nth_iter: int,
+        drone_or_ltc: str = "drone",
+        is_condensed: bool = False,
+    ):
+        logging_config = LoggingConfig(
+            sim_name="temp",
+            results_dir=results_dir,
+            log_every_nth_iter=log_every_nth_iter,
+        )
+        if drone_or_ltc == "drone":
+            sim_config = DroneSimulation.get_sim_config(
+                backend="casadi",
+                num_intervals=100,
+                is_condensed=is_condensed,
+                logging_config=logging_config,
+            )
+            ocp = DroneSimulation(sim_config=sim_config)
+        else:
+            sim_config = LaptimeSimulation.get_sim_config(
+                track="data/tracks/Catalunya.csv",
+                backend="casadi",
+                num_intervals=100,
+                is_condensed=is_condensed,
+                logging_config=logging_config,
+            )
+            ocp = LaptimeSimulation(sim_config=sim_config)
+
+        x0 = ocp.get_init_guess()
+        solution, info = ocp.solve(x0, max_iter=self.num_iter, print_level=0,)
+
+        return ocp.logging_dir
+
+    @parameterized.expand(
+        [[0, 2, 0], [1, 2, 1], [10, 2, 1],]
+    )
+    def test_correct_files_are_created(
+        self, log_every_nth_iter, expected_num_csv, expected_num_parquet
+    ):
         with TemporaryDirectory() as temp_dir:
-            # FIXME: this is unneceesarily expensive to use an LTC
-            # But we have only implemented logging for the FixedGrid subclass only
-            # at the moment...
-            ocp = LaptimeSimulation(
-                sim_config=LaptimeSimulation.get_sim_config(
-                    track="data/tracks/Catalunya.csv",
-                    backend="casadi",
-                    num_intervals=100,
-                    logging_config={
-                        "results_dir": temp_dir,  # store in a new directory at current directory
-                        "sim_name": "Temp",
-                        "log_final_iter": True,
-                        "log_metrics_history": True,
-                        "log_every_nth_iter": 1,  # if 0, logging is off
-                    },
-                )
+            logging_dir = self._run_and_log(
+                results_dir=temp_dir, log_every_nth_iter=log_every_nth_iter
             )
 
-            x0 = ocp.get_init_guess()
+            # Check the number of log files are correct
+            # one csv for final results and 1 csv for metrics history should always be
+            # written
+            # log_every_nth_iter = 0 -> no parquet files for all iterations
+            csv_files = glob.glob(os.path.join(logging_dir, "*.csv"))
+            self.assertEqual(len(csv_files), expected_num_csv)
 
-            solution, info = ocp.solve(x0, max_iter=self.num_iter, print_level=0,)
+            parquet_files = glob.glob(os.path.join(logging_dir, "*.parquet"))
+            self.assertEqual(len(parquet_files), expected_num_parquet)
+
+    def test_no_logging(self):
+        """Just a smoke test. Kind of difficult to verify it doesn't produce anything"""
+        sim_config = DroneSimulation.get_sim_config(
+            backend="casadi", num_intervals=100,
+        )
+        ocp = DroneSimulation(sim_config=sim_config)
+        x0 = ocp.get_init_guess()
+        solution, info = ocp.solve(x0, max_iter=self.num_iter, print_level=0)
+
+    @parameterized.expand(itertools.product(("drone", "ltc"), (True, False)))
+    def test_log_every_iter(self, drone_or_ltc, is_condensed):
+        with TemporaryDirectory() as temp_dir:
+            logging_dir = self._run_and_log(
+                is_condensed=is_condensed,
+                results_dir=temp_dir,
+                log_every_nth_iter=1,
+                drone_or_ltc=drone_or_ltc,
+            )
 
             # Check the number of log files are correct
             # There should be:
@@ -44,18 +100,18 @@ class TestOCPLogging(unittest.TestCase):
             # - 1 metrics history csv
             expected_num_csv = 2
             expected_num_parquet = 1
-            csv_files = glob.glob(os.path.join(ocp.logging_dir, "*.csv"))
+            csv_files = glob.glob(os.path.join(logging_dir, "*.csv"))
             self.assertEqual(len(csv_files), expected_num_csv)
 
-            parquet_files = glob.glob(os.path.join(ocp.logging_dir, "*.parquet"))
+            parquet_files = glob.glob(os.path.join(logging_dir, "*.parquet"))
             self.assertEqual(len(parquet_files), expected_num_parquet)
 
             # Ensure the max constraiont violation agrees with inf_pr
             combined_df = pq.read_pandas(
-                os.path.join(ocp.logging_dir, "all_iters.parquet")
+                os.path.join(logging_dir, "all_iters.parquet")
             ).to_pandas()
             metrics_history_df = pd.read_csv(
-                os.path.join(ocp.logging_dir, "metrics_history.csv")
+                os.path.join(logging_dir, "metrics_history.csv")
             )
 
             # FIXME: it's not nice to get constraint names from here...
@@ -70,6 +126,5 @@ class TestOCPLogging(unittest.TestCase):
                     metrics_history_df["max_violation_con_name"][it], column
                 )
                 self.assertAlmostEqual(
-                    metrics_history_df["max_violation_distance"][it],
-                    iter_df["distance"][idx],
+                    metrics_history_df["max_violation_mesh"][it], iter_df["mesh"][idx],
                 )


### PR DESCRIPTION
- make logging more generic so that it works with all kinds of ocp
- creates more stringent tests for logging
- simplifies logging possibilities: when logging_config is not provided,
nothing is logged, when loggign_config is provided, but
log_every_nth_iter==0, then only final results and metrics history is
logged. Otherwise additonally, the result at every nth iteration is
logged, with the last itertion result also appended.