### PR TITLE
make outputs collection more automatic

### DIFF
--- a/lumos/models/composition.py
+++ b/lumos/models/composition.py
@@ -162,6 +162,11 @@ class CompositeModel:
 
         model = self
         for name in path_to_submodel:
+            if name not in model._submodels:
+                raise KeyError(
+                    f"{name} is not a valid submodel of {type(model)}. "
+                    "Valid ones are {model.get_submodel_names()}"
+                )
             model = model._submodels[name]
 
         return model

--- a/lumos/models/simple_vehicle_on_track.py
+++ b/lumos/models/simple_vehicle_on_track.py
@@ -40,8 +40,8 @@ class SimpleVehicleOnTrack(StateSpaceModel):
         }
 
         # Pick out vehicle params. NOT DONE! NOT EASY!
-        vehicle_return = self.get_submodel("vehicle").forward(
-            states=vehicle_states, inputs=vehicle_inputs
+        vehicle_return = self.call_submodel(
+            "vehicle", states=vehicle_states, inputs=vehicle_inputs
         )
 
         # Call Kinematics model
@@ -61,7 +61,8 @@ class SimpleVehicleOnTrack(StateSpaceModel):
         kinematic_inputs = dict(**track_inputs, **inputs_from_vehicle)
 
         # Pick out vehicle params. NOT DONE! NOT EASY!
-        kinematics_return = self.get_submodel("kinematics").forward(
+        kinematics_return = self.call_submodel(
+            "kinematics",
             states=kinematic_states,
             inputs=kinematic_inputs,
             mesh=mesh,
@@ -74,10 +75,8 @@ class SimpleVehicleOnTrack(StateSpaceModel):
             **{k: v * dt_ds for k, v in vehicle_return.states_dot.items()},
         }
 
-        # Assemble final outputs
-        outputs = self.combine_submodel_outputs(
-            vehicle=vehicle_return.outputs, kinematics=kinematics_return.outputs
-        )
+        # Assemble final outputs - there are no direct outputs from the current one
+        outputs = self.make_outputs_dict()
 
         residuals = vehicle_return.residuals
 


### PR DESCRIPTION
- create `call_submodel` methods to use instead of getting the submodel
  manually and then calling it. This call also handles input checking,
result buffering (for automtic colleciton later).
- the submodel returns are now stored in a buffer after it is called.
  The buffer is cleared when the submodel outputs are collected.
- to avoid contamination of results in the buffer:
1) a RuntimeError will be thrown if the corresponding buffer entry
   already exists when a submodel is called (eg, happens when one calls
the same submodel twice before outputs collection)
2) a KeyError will be thrown if the outputs collection happens before
   all submodels are called