### PR TITLE
working automatic assembly of residuals

### DIFF
--- a/lumos/models/simple_vehicle_on_track.py
+++ b/lumos/models/simple_vehicle_on_track.py
@@ -12,8 +12,6 @@ from lumos.models.vehicles.simple_vehicle import SimpleVehicle
     + SimpleVehicle.get_direct_group_names("states"),
     inputs=SimpleVehicle.get_direct_group_names("inputs")
     + ("track_curvature", "track_heading"),
-    residuals=TrackPosition2D.get_direct_group_names("residuals")
-    + SimpleVehicle.get_direct_group_names("residuals"),
 )
 class SimpleVehicleOnTrack(StateSpaceModel):
     def __init__(self, *args, **kwargs):
@@ -62,10 +60,7 @@ class SimpleVehicleOnTrack(StateSpaceModel):
 
         # Pick out vehicle params. NOT DONE! NOT EASY!
         kinematics_return = self.call_submodel(
-            "kinematics",
-            states=kinematic_states,
-            inputs=kinematic_inputs,
-            mesh=mesh,
+            "kinematics", states=kinematic_states, inputs=kinematic_inputs, mesh=mesh,
         )
 
         # Convert to distance domain derivatives
@@ -78,10 +73,6 @@ class SimpleVehicleOnTrack(StateSpaceModel):
         # Assemble final outputs - there are no direct outputs from the current one
         outputs = self.make_outputs_dict()
 
-        residuals = vehicle_return.residuals
-
         return self.make_state_space_model_return(
-            states_dot=states_dot,
-            outputs=outputs,
-            residuals=residuals,
+            states_dot=states_dot, outputs=outputs,
         )


### PR DESCRIPTION
## Summary
In this PR, we make the collection of residuals automatic, so the users no longer have to pipe residuals from leaf node submodels all the way manually to top level model.

## How does it work under the hood?
What has been done is very similar to `con_outputs`. We leverage the mechanism that automatically collects outputs, and the user have to define what subsets of the outputs constitute a 'residual'. 

## Why is it different to how we treat `con_outputs`?
- con_outputs allow the user to set equality and inequality bounds on the variables, while residuals are always constrained to 0
- con_outputs are added to decision variables, and residuals are not.
- con_outputs are a property of the problem, and set up with the definition of an optimal control problem (OCP).
- residuals are a property of the model, it defines a DAE. Imagine when we can use different tire sumodels in a vehicle model, while some submodels contain residuals as they are formulated as DAEs, while some others don't, we want the top-level model to be able to automatically decide what residuals it have with different submodel compositions! As such, residuals are a model property

## How should I change my model?
At the model where residuals exist:
- add some names to the outputs that we would later use as residuals, eg, "res_ax", "res_ay". These simply add some outputs to the model, they don't automatically become residuals yet. 
- define the residual names, which must be a subset of the outputs.
- populate the residual outputs just like any other ordinary outputs

And that's it, you only need to do it at the model where the residuals are computed.